### PR TITLE
test: wire readonly suite to non-destructive composable runner

### DIFF
--- a/tests/post_deploy_functional/main_test.go
+++ b/tests/post_deploy_functional/main_test.go
@@ -32,5 +32,5 @@ func TestAcrModule(t *testing.T) {
 		SetTestConfigFileName(infraTFVarFileNameDefault).
 		Build()
 
-	lib.RunSetupTestTeardown(t, *ctx, testimpl.TestAcrComplete)
+	lib.RunSetupTestTeardown(t, *ctx, testimpl.TestComposableComplete)
 }

--- a/tests/post_deploy_functional_readonly/main_test.go
+++ b/tests/post_deploy_functional_readonly/main_test.go
@@ -32,5 +32,5 @@ func TestAcrModule(t *testing.T) {
 		SetTestConfigFileName(infraTFVarFileNameDefault).
 		Build()
 
-	lib.RunSetupTestTeardown(t, *ctx, testimpl.TestAcrComplete)
+	lib.RunNonDestructiveTest(t, *ctx, testimpl.TestComposableComplete)
 }

--- a/tests/testimpl/test_impl.go
+++ b/tests/testimpl/test_impl.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestAcrComplete(t *testing.T, ctx types.TestContext) {
+func TestComposableComplete(t *testing.T, ctx types.TestContext) {
 	t.Run("TestAlwaysSucceeds", func(t *testing.T) {
 		assert.Equal(t, "foo", "foo", "Should always be the same!")
 		assert.NotEqual(t, "foo", "bar", "Should never be the same!")


### PR DESCRIPTION
## What

Wires the readonly suite to a non-destructive runner with a `TestComposable*` testimpl function:

- `tests/post_deploy_functional_readonly` was calling `lib.RunSetupTestTeardown` (apply → test → **destroy**) — so the "read-only" suite was not read-only. Switched it to `lib.RunNonDestructiveTest`.
- That runner requires the testimpl function to be named `TestComposable*` (lcaf `demandAllTests2RunAreComposableOnes` calls `t.FailNow()` otherwise). The shared testimpl function `TestAcrComplete` is renamed to `TestComposableComplete` and references updated in both test dirs.

## Why it was invisible

`make test` excludes `post_deploy_functional_readonly`, so CI never ran this suite — neither the destructive runner nor the non-composable name surfaced. Background: launchbynttdata/launch-workflows#92.

## Safety

- The testimpl function is already **read-only** (reads `terraform.Output` + Azure `ContainerRegistryExists`/`GetContainerRegistry` asserts; no mutation), so it is correct to run under `RunNonDestructiveTest` unchanged.
- The destructive `post_deploy_functional` suite keeps `RunSetupTestTeardown`; only the function name changed there.
- Verified locally: `go build ./tests/...` and `go vet` pass (Go 1.26.1), the readonly guard passes, gofmt clean.
- Independent of the open v4 PR #28 (that PR touches module/example files only — no test files).

Generated with [Claude Code](https://claude.com/claude-code)
